### PR TITLE
fix: chromium license location on macOS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/gulp-electron",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/gulp-electron",
-      "version": "1.33.0",
+      "version": "1.34.0",
       "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/gulp-electron",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "description": "gulp plugin for packaging Electron into VS Code",
   "main": "src/index.js",
   "scripts": {

--- a/src/darwin.js
+++ b/src/darwin.js
@@ -323,6 +323,20 @@ function addCredits(opts) {
   return es.duplex(input, es.merge(input, credits));
 }
 
+function moveChromiumLicense(opts) {
+  var newLicensePath = path.join(
+    getOriginalAppFullName(opts),
+    "Contents",
+    "Resources"
+  );
+  return es.mapSync(function (f) {
+    if (!f.isNull() && !f.isDirectory() && f.path === "LICENSES.chromium.html") {
+      f.dirname = newLicensePath;
+    }
+    return f;
+  });
+}
+
 function renameApp(opts) {
   var originalAppName = getOriginalAppName(opts);
   var originalAppNameRegexp = new RegExp("^" + getOriginalAppFullName(opts));
@@ -403,6 +417,7 @@ exports.patch = function (opts) {
     .pipe(patchHelperInfoPlist(opts))
     .pipe(createEntitlementsPlist(opts))
     .pipe(addCredits(opts))
+    .pipe(moveChromiumLicense(opts))
     .pipe(renameApp(opts))
     .pipe(renameAppHelper(opts));
 

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -110,6 +110,52 @@ describe("electron", function () {
           cb();
         });
     });
+
+    it("should move chromium license", function (cb) {
+      this.timeout(1000 * 60 * 5 /* 5 minutes */);
+
+      var files = {};
+      process.chdir(__dirname);
+
+      vfs
+        .src("src/**/*")
+        .pipe(
+          electron({
+            version: "22.3.6",
+            platform: "darwin",
+            darwinIcon: path.join(__dirname, "resources", "myapp.icns"),
+            darwinBundleIdentifier:
+              "com.github.joaomoreno.gulpatomelectron.faketemplateapp",
+            token: process.env["GITHUB_TOKEN"],
+          })
+        )
+        .on("data", function (f) {
+          assert(!files[f.relative]);
+          files[f.relative] = f;
+        })
+        .on("error", cb)
+        .on("end", function () {
+          assert(
+            files[
+            path.join(
+              "FakeTemplateApp.app",
+              "Contents",
+              "Resources",
+              "LICENSES.chromium.html",
+            )
+            ]
+          );
+          assert(
+            !Object.keys(files).some(function (k) {
+              return k.startsWith(
+                "LICENSES.chromium.html"
+              );
+            })
+          );
+
+          cb();
+        });
+    });
   });
 
   describe("linux", function () {


### PR DESCRIPTION
Will move the license file under `Application.app/Contents/Resources` from root

Needed for https://github.com/microsoft/vscode/pull/181113