### PR TITLE
Bump version of "rcedit" package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "mkdirp": "^0.5.1",
     "plist": "^3.0.1",
     "progress": "^1.1.8",
-    "rcedit": "^0.3.0",
+    "rcedit": "^1.1.0",
     "rimraf": "^2.4.2",
     "semver": "^5.7.2",
     "sumchecker": "^3.0.1",


### PR DESCRIPTION
The old version of **rcedit** links against Visual Studio 2010 Redistributable files (msvcp100.dll and msvcr100.dll), which are no longer supported.

This makes it difficult to setup build environment in github workflow.

I changed the version 1.1.0, which is the same vscode uses