### PR TITLE
fix: only set authorization header when token is present

### DIFF
--- a/src/download.js
+++ b/src/download.js
@@ -59,7 +59,9 @@ async function getDownloadUrl(
   });
 
   const { url, headers } = requestOptions;
-  headers.authorization = `token ${token}`;
+  if (token) {
+    headers.authorization = `token ${token}`;
+  }
 
   const response = await got(url, {
     followRedirect: false,


### PR DESCRIPTION
This PR fixes a bug that causes downloading failure when `token` is not specified in options.

The cause of the failure is that not specifying `token` leads to `token undefined` as `Authorization` header, which will be rejected by GitHub API with a 401 response.