### PR TITLE
fix: downloading from custom repository

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/gulp-electron",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/gulp-electron",
-      "version": "1.37.0",
+      "version": "1.37.1",
       "license": "MIT",
       "dependencies": {
         "@electron/get": "^4.0.1",
@@ -32,7 +32,7 @@
         "mocha": "^10.2.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=22"
       }
     },
     "node_modules/@electron/get": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/gulp-electron",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "description": "gulp plugin for packaging Electron into VS Code",
   "main": "src/index.js",
   "scripts": {
@@ -11,7 +11,7 @@
     "url": "https://github.com/microsoft/vscode-gulp-electron.git"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=22"
   },
   "keywords": [
     "gulpplugin",

--- a/src/download.js
+++ b/src/download.js
@@ -8,7 +8,7 @@ var es = require("event-stream");
 var zfs = require("gulp-vinyl-zip");
 var filter = require("gulp-filter");
 const { Octokit } = require("@octokit/rest");
-const got = require("got");
+const { got } = require("got");
 const sumchecker = require('sumchecker');
 
 async function getDownloadUrl(

--- a/test/download.test.js
+++ b/test/download.test.js
@@ -54,6 +54,30 @@ describe("download", function () {
       });
   });
 
+  it("should download from a custom repo", function (cb) {
+    var didSeeInfoPList = false;
+
+    download({
+      version: "32.2.3",
+      repo: "deepak1556/electron-debug-version",
+      platform: "darwin",
+      arch: "arm64",
+      token: process.env["GITHUB_TOKEN"],
+    })
+      .on("data", function (f) {
+        if (
+          f.relative === path.join("Electron.app", "Contents", "Info.plist")
+        ) {
+          didSeeInfoPList = true;
+        }
+      })
+      .on("error", cb)
+      .on("end", function () {
+        assert(didSeeInfoPList);
+        cb();
+      });
+  });
+
   it("should download PDBs", function (cb) {
     var didSeePDBs = false;
 


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/vscode-gulp-electron/pull/21, `got` is an esm dependency

1) Update test to exercise the got code path
2) Bump engine version to support require esm