### PR TITLE
fix: helper app bundle names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/gulp-electron",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/gulp-electron",
-      "version": "1.38.1",
+      "version": "1.38.2",
       "license": "MIT",
       "dependencies": {
         "@electron/get": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/gulp-electron",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "description": "gulp plugin for packaging Electron into VS Code",
   "main": "src/index.js",
   "scripts": {

--- a/src/darwin.js
+++ b/src/darwin.js
@@ -226,11 +226,9 @@ function patchHelperInfoPlist(opts) {
   var input = es.through();
   var output = input.pipe(
     es.map(function (f, cb) {
-      if (
-        !/Contents\/Frameworks\/Electron\ Helper( \w+)?\.app\/Contents\/Info.plist$/i.test(
-          f.relative
-        )
-      ) {
+      const match = /Contents\/Frameworks\/Electron\ Helper( \(\w+\))?\.app\/Contents\/Info.plist$/i.exec(
+        f.relative);
+      if (!match) {
         return cb(null, f);
       }
 
@@ -246,24 +244,14 @@ function patchHelperInfoPlist(opts) {
 
       f.contents.on("end", function () {
         var infoPlist = plist.parse(contents.toString("utf8"));
-        var match = /\.helper\.([^.]+)$/.exec(
-          infoPlist["CFBundleIdentifier"] || ""
-        );
-        var suffix = match ? match[1] : "";
+        var suffix = match[1] ?? "";
 
         if (opts.darwinBundleIdentifier) {
           infoPlist["CFBundleIdentifier"] =
             opts.darwinBundleIdentifier + ".helper";
-
-          if (suffix) {
-            infoPlist["CFBundleIdentifier"] += "." + suffix;
-          }
         }
 
-        infoPlist["CFBundleName"] = opts.productName + " Helper";
-        if (suffix) {
-          infoPlist["CFBundleName"] += " " + suffix;
-        }
+        infoPlist["CFBundleName"] = `${opts.productName} Helper${suffix}`;
 
         if (infoPlist["CFBundleDisplayName"]) {
           infoPlist["CFBundleDisplayName"] = infoPlist["CFBundleName"];

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -115,6 +115,33 @@ describe("electron", function () {
           assert.equal(infoPlist["CFBundleName"], "FakeTemplateApp")
           assert.equal(infoPlist["CFBundleDisplayName"], "FakeTemplateApp")
 
+          // Added helper Info.plist validation
+          var helperBasePath = path.join(
+            "FakeTemplateApp.app",
+            "Contents",
+            "Frameworks"
+          );
+          var helperApps = [
+            "FakeTemplateApp Helper.app",
+            "FakeTemplateApp Helper (GPU).app",
+            "FakeTemplateApp Helper (Renderer).app",
+            "FakeTemplateApp Helper (Plugin).app"
+          ];
+          helperApps.forEach(function (appName) {
+            var helperPlistPath = path.join(helperBasePath, appName, "Contents", "Info.plist");
+            if (files[helperPlistPath]) {
+              var helperPlist = plist.parse(files[helperPlistPath].contents.toString("utf8"));
+              var expectedName = appName.replace(/\.app$/, "");
+              assert.equal(helperPlist["CFBundleName"], expectedName, "CFBundleName should be updated");
+              if (helperPlist["CFBundleDisplayName"]) {
+                assert.equal(helperPlist["CFBundleDisplayName"], expectedName, "CFBundleDisplayName should be updated");
+              }
+              if (helperPlist["CFBundleExecutable"]) {
+                assert.equal(helperPlist["CFBundleExecutable"], expectedName, "CFBundleExecutable should be renamed");
+              }
+            }
+          });
+
           cb();
         });
     });


### PR DESCRIPTION
**Before**

Bundle id : com.github.Electron.helper
Bundle name: Electron Helper (plugin)

**After**

Bundle id : `com.<application>.helper`
Bundle name: Application Helper (plugin)

Found while debugging https://github.com/microsoft/vscode/pull/261148