### PR TITLE
fix: use display name for miniapp bundle directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/gulp-electron",
-  "version": "1.41.1",
+  "version": "1.41.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/gulp-electron",
-      "version": "1.41.1",
+      "version": "1.41.2",
       "license": "MIT",
       "dependencies": {
         "@electron/get": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/gulp-electron",
-  "version": "1.41.1",
+  "version": "1.41.2",
   "description": "gulp plugin for packaging Electron into VS Code",
   "main": "src/index.js",
   "scripts": {

--- a/src/darwin.js
+++ b/src/darwin.js
@@ -668,6 +668,7 @@ function renameMiniApp(opts) {
   var originalMiniAppName = getOriginalMiniAppName(opts);
   var originalMiniAppFullName = getOriginalMiniAppFullName(opts);
   var miniAppName = getMiniAppName(opts);
+  var miniAppBundleName = getMiniAppBundleName(opts);
   var miniAppFullName = getMiniAppFullName(opts);
 
   return rename(function (path) {
@@ -686,7 +687,7 @@ function renameMiniApp(opts) {
       path.basename === originalMiniAppName &&
       path.extname === ".app"
     ) {
-      path.basename = miniAppName;
+      path.basename = miniAppBundleName;
       return;
     }
 

--- a/test/darwin.test.js
+++ b/test/darwin.test.js
@@ -42,6 +42,16 @@ function createStreamFile(relativePath, contents) {
   });
 }
 
+function createDirectory(relativePath) {
+  return new File({
+    cwd: process.cwd(),
+    base: process.cwd(),
+    path: path.join(process.cwd(), relativePath),
+    contents: null,
+    stat: { isDirectory: function () { return true; } },
+  });
+}
+
 var describeDarwin = process.platform === "darwin" ? describe : describe.skip;
 
 describeDarwin("darwin patch", function () {
@@ -171,6 +181,13 @@ describeDarwin("darwin patch", function () {
       "Electron MiniApp"
     );
 
+    var miniAppDir = path.join(
+      "Electron.app",
+      "Contents",
+      "Applications",
+      "Electron MiniApp.app"
+    );
+
     runPatch(
       {
         version: "35.0.0",
@@ -183,6 +200,7 @@ describeDarwin("darwin patch", function () {
       [
         createStreamFile(miniInfoPlist, miniAppPlist),
         createFile(miniExec, "exec"),
+        createDirectory(miniAppDir),
       ],
       function (err, files) {
         if (err) {
@@ -199,6 +217,16 @@ describeDarwin("darwin patch", function () {
           "Info.plist"
         );
         assert(files[renamedBundlePlist], "Bundle should use darwinMiniAppDisplayName for .app name");
+
+        var shortNameBundlePlist = path.join(
+          "TestApp.app",
+          "Contents",
+          "Applications",
+          "Agents - Insiders.app",
+          "Contents",
+          "Info.plist"
+        );
+        assert(!files[shortNameBundlePlist], "Bundle must NOT use short name for .app directory");
 
         var infoPlist = plist.parse(files[renamedBundlePlist].contents.toString("utf8"));
         // CFBundleDisplayName should be the display name
@@ -219,6 +247,22 @@ describeDarwin("darwin patch", function () {
           "Agents - Insiders"
         );
         assert(files[renamedExec], "Executable should use darwinMiniAppName (short name)");
+
+        var renamedAppDir = path.join(
+          "TestApp.app",
+          "Contents",
+          "Applications",
+          "Visual Studio Code Agents - Insiders.app"
+        );
+        assert(files[renamedAppDir], ".app directory should use darwinMiniAppDisplayName");
+
+        var shortNameAppDir = path.join(
+          "TestApp.app",
+          "Contents",
+          "Applications",
+          "Agents - Insiders.app"
+        );
+        assert(!files[shortNameAppDir], ".app directory must NOT use short name");
 
         cb();
       }


### PR DESCRIPTION
Followup to https://github.com/microsoft/vscode-gulp-electron/pull/40

The top level directory was not renamed as expected. Refs https://monacotools.visualstudio.com/Monaco/_build/results?buildId=429428&view=logs&j=7c206f6d-993c-583c-875a-239a70ef97fe&t=7504d5e3-2a33-5c65-18e8-7b3d6b2a8e2f