### PR TITLE
Retry transient network errors when downloading Electron

### DIFF
--- a/src/download.js
+++ b/src/download.js
@@ -11,6 +11,58 @@ const { Octokit } = require("@octokit/rest");
 const { got } = require("got");
 const sumchecker = require('sumchecker');
 
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "ETIMEDOUT",
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "EPIPE",
+  "ENOTFOUND",
+  "ENETUNREACH",
+  "EAI_AGAIN",
+  "EHOSTUNREACH",
+]);
+
+function isTransientNetworkError(err) {
+  if (!err) {
+    return false;
+  }
+  if (err.code && TRANSIENT_NETWORK_ERROR_CODES.has(err.code)) {
+    return true;
+  }
+  // got wraps the underlying cause; check it as well.
+  if (err.cause && err.cause.code && TRANSIENT_NETWORK_ERROR_CODES.has(err.cause.code)) {
+    return true;
+  }
+  return false;
+}
+
+async function withRetry(name, fn, { retries = 5, baseDelayMs = 2000 } = {}) {
+  let attempt = 0;
+  for (;;) {
+    try {
+      return await fn();
+    } catch (err) {
+      attempt++;
+      if (attempt > retries || !isTransientNetworkError(err)) {
+        throw err;
+      }
+      const delay = Math.min(baseDelayMs * Math.pow(2, attempt - 1), 30000);
+      const code = (err && err.code) || (err.cause && err.cause.code) || "unknown";
+      console.warn(
+        `[gulp-electron] ${name} failed with ${code} (attempt ${attempt}/${retries}); retrying in ${delay}ms...`
+      );
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+}
+
+const GOT_RETRY_OPTIONS = {
+  limit: 5,
+  methods: ["GET", "HEAD"],
+  errorCodes: Array.from(TRANSIENT_NETWORK_ERROR_CODES),
+  backoffLimit: 30000,
+};
+
 async function getDownloadUrl(
   ownerRepo, customTag,
   { version, platform, arch, token, artifactName, artifactSuffix }
@@ -61,11 +113,14 @@ async function getDownloadUrl(
   const { url, headers } = requestOptions;
   headers.authorization = `token ${token}`;
 
-  const response = await got(url, {
-    followRedirect: false,
-    method: "HEAD",
-    headers,
-  });
+  const response = await withRetry("HEAD release asset", () =>
+    got(url, {
+      followRedirect: false,
+      method: "HEAD",
+      headers,
+      retry: GOT_RETRY_OPTIONS,
+    })
+  );
 
   return response.headers.location;
 }
@@ -119,7 +174,9 @@ async function download(opts) {
   );
 
   if (opts.repo) {
-    const url = await getDownloadUrl(opts.repo, opts.tag, downloadOpts);
+    const url = await withRetry("resolve release asset URL", () =>
+      getDownloadUrl(opts.repo, opts.tag, downloadOpts)
+    );
 
     downloadOpts = {
       ...downloadOpts,
@@ -134,7 +191,9 @@ async function download(opts) {
   const start = new Date();
   bar.start = start;
 
-  return await downloadArtifact(downloadOpts);
+  return await withRetry(`download ${opts.artifactName || "electron"}`, () =>
+    downloadArtifact(downloadOpts)
+  );
 }
 
 function downloadStream(opts) {


### PR DESCRIPTION
## What

Adds retry-with-exponential-backoff to the three network operations in the download path:

1. The `got` HEAD request that resolves a release asset's redirect URL — now passes explicit `retry` options (limit 5, GET+HEAD, transient error codes) plus an outer `withRetry` wrapper.
2. `getDownloadUrl()` — wrapped in `withRetry` so Octokit/network failures during release/asset listing are retried.
3. `downloadArtifact()` (the `@electron/get` call that actually pulls the zip from `release-assets.githubusercontent.com`) — wrapped in `withRetry`. This is the path that triggered the failure that motivated this change.

Retried error codes: `ETIMEDOUT`, `ECONNRESET`, `ECONNREFUSED`, `EPIPE`, `ENOTFOUND`, `ENETUNREACH`, `EAI_AGAIN`, `EHOSTUNREACH`. Up to 5 retries with exponential backoff capped at 30s. Errors outside that set fail fast as before. The helper inspects `err.cause.code` too, since `got` wraps the underlying `getaddrinfo` error.

## Why

A single transient DNS/network blip (e.g. `getaddrinfo ENOTFOUND release-assets.githubusercontent.com`) currently fails the entire `vscode-win32-x64-min-ci` build. Observed in [vscode build 437760](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=437760):

```
[15:29:24] 'vscode-win32-x64-min-ci' errored after 17 s
[15:29:24] RequestError: getaddrinfo ENOTFOUND release-assets.githubusercontent.com
    at ClientRequest.<anonymous> (.../@vscode/gulp-electron/.../got/.../core/index.js:868)
```

The download is a versioned, content-addressable Electron release asset, so retrying produces identical bytes and is safe.

## Testing

- `node --check src/download.js` (syntax)
- No new unit tests added — the existing tests in [test/download.test.js](test/download.test.js) are real-network integration tests with no mocking framework; this change is a pure resilience wrapper around existing happy-path code.